### PR TITLE
feat: connect to queue and consume events

### DIFF
--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -42,7 +42,6 @@ jobs:
         uses: anchore/scan-action@v3
         with:
           image: "localbuild/testimage:latest"
-          acs-report-enable: true
           fail-build: true
           severity-cutoff: "high"
       - name: Upload Anchore Scan Report

--- a/manifests/deployment.yml
+++ b/manifests/deployment.yml
@@ -20,6 +20,8 @@ spec:
           imagePullPolicy: Always
           envFrom:
             - secretRef:
+                name: rtd-file-register-projector-consumer
+            - secretRef:
                 name: mongo-credentials
           resources:
             limits:

--- a/pom.xml
+++ b/pom.xml
@@ -66,11 +66,17 @@
 			<artifactId>de.flapdoodle.embed.mongo</artifactId>
 			<scope>test</scope>
 		</dependency>
-<!--		<dependency>-->
-<!--			<groupId>org.springframework.kafka</groupId>-->
-<!--			<artifactId>spring-kafka-test</artifactId>-->
-<!--			<scope>test</scope>-->
-<!--		</dependency>-->
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-test-support</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<dependencyManagement>

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/configuration/AppConfiguration.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/configuration/AppConfiguration.java
@@ -1,5 +1,6 @@
 package it.gov.pagopa.rtd.ms.rtdmsfilereporter.configuration;
 
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.FileReportCommandFactory;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.repository.FileReportRepository;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.service.FileReportService;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.service.FileReportServiceImpl;
@@ -24,5 +25,10 @@ public class AppConfiguration {
   @Bean
   public FileReportRepository getFileReportRepository(FileReportDao dao) {
     return new FileReportRepositoryImpl(dao, FileReportEntityMapper.createEntityDomainMapper());
+  }
+
+  @Bean
+  public FileReportCommandFactory getFileReportCommandFactory() {
+    return new FileReportCommandFactory();
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/FileReportControllerImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/FileReportControllerImpl.java
@@ -20,6 +20,6 @@ public class FileReportControllerImpl implements FileReportController {
   @Override
   public FileReportDto getFileReport(Collection<String> senderCodes) {
     log.info("GET file report for sender codes: {}", senderCodes.toString());
-    return modelMapper.map(fileReportService.getFileReport(senderCodes), FileReportDto.class);
+    return modelMapper.map(fileReportService.getAggregateFileReport(senderCodes), FileReportDto.class);
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/FileReportCommandFactory.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/FileReportCommandFactory.java
@@ -1,0 +1,20 @@
+package it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain;
+
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileMetadata;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model.EventStatusEnum;
+import java.util.function.BiConsumer;
+
+public class FileReportCommandFactory {
+
+  public BiConsumer<FileReport, FileMetadata> getCommandByStatus(String status) {
+    switch (EventStatusEnum.valueOf(status)) {
+      case ACK_TO_DOWNLOAD:
+        return (fileReport, fileMetadata) -> fileReport.addAckToDownload(fileMetadata.getName());
+      case ACK_DOWNLOADED:
+        return (fileReport, fileMetadata) -> fileReport.removeAckToDownload(fileMetadata.getName());
+      default:
+        return FileReport::addFileOrUpdateStatusIfPresent;
+    }
+  }
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileMetadata.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileMetadata.java
@@ -23,7 +23,7 @@ public class FileMetadata {
 
   @NotNull
   @NotBlank
-  private String status;
+  private FileStatusEnum status;
 
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
   private LocalDateTime transmissionDate;
@@ -32,7 +32,7 @@ public class FileMetadata {
     return createNewFileMetadataWithStatus(name, null);
   }
 
-  public static FileMetadata createNewFileMetadataWithStatus(String name, String status) {
+  public static FileMetadata createNewFileMetadataWithStatus(String name, FileStatusEnum status) {
     return new FileMetadata(name, null, status, LocalDateTime.now());
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileReport.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileReport.java
@@ -4,7 +4,6 @@ import static java.util.Collections.emptyList;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import javax.validation.constraints.NotBlank;

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileReport.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileReport.java
@@ -2,7 +2,9 @@ package it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model;
 
 import static java.util.Collections.emptyList;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import javax.validation.constraints.NotBlank;
@@ -36,15 +38,8 @@ public class FileReport {
     filesUploaded.removeIf(file -> file.getName().equals(name));
   }
 
-  public void updateFileStatus(@NotNull String filename, String status) {
-
-    if (filesUploaded.stream().anyMatch(file -> file.getName().equals(filename))) {
-      filesUploaded.stream().filter(file -> file.getName().equals(filename))
-          .forEach(file -> file.setStatus(status));
-    } else {
-      FileMetadata fileMetadata = FileMetadata.createNewFileMetadataWithStatus(filename, status);
-      filesUploaded.add(fileMetadata);
-    }
+  public void addSenderCode(String senderCode) {
+    senderCodes.add(senderCode);
   }
 
   public void addAckToDownload(String filename) {
@@ -55,8 +50,30 @@ public class FileReport {
     ackToDownload.remove(filename);
   }
 
+  public void addFileOrUpdateStatusIfPresent(FileMetadata fileMetadata) {
+
+    if (filesUploaded.stream().anyMatch(file -> file.getName().equals(fileMetadata.getName()))) {
+      filesUploaded.stream()
+          .filter(file -> file.getName().equals(fileMetadata.getName()))
+          .forEach(file -> file.setStatus(fileMetadata.getStatus()));
+    } else {
+      filesUploaded.add(fileMetadata);
+    }
+  }
+
+  public void removeFilesOlderThan(int days) {
+    filesUploaded.removeIf(
+        file -> file.getTransmissionDate().isBefore(LocalDateTime.now().minusDays(days)));
+  }
+
   public static FileReport createFileReport() {
     return new FileReport(null, new HashSet<>(), new HashSet<>(), new HashSet<>());
+  }
+
+  public static FileReport createFileReportWithSenderCode(String senderCode) {
+    var fileReport = createFileReport();
+    fileReport.addSenderCode(senderCode);
+    return fileReport;
   }
 
   public static FileReport mergeFileReports(FileReport firstReport, FileReport secondReport) {

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileStatusEnum.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileStatusEnum.java
@@ -1,0 +1,9 @@
+package it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model;
+
+public enum FileStatusEnum {
+  RECEIVED_BY_PAGOPA,
+  VALIDATED_BY_PAGOPA,
+  SENT_TO_AGENZIA_DELLE_ENTRATE,
+  ACK_TO_DOWNLOAD,
+  ACK_DOWNLOADED
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/repository/FileReportRepository.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/repository/FileReportRepository.java
@@ -3,12 +3,13 @@ package it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.repository;
 
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
 import java.util.Collection;
+import java.util.Optional;
 
 public interface FileReportRepository {
 
   Collection<FileReport> getReportsBySenderCodes(Collection<String> senderCodes);
 
-  FileReport getReportBySenderCode(String senderCode);
+  Optional<FileReport> getReportBySenderCode(String senderCode);
 
   void save(FileReport fileReport);
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/repository/FileReportRepository.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/repository/FileReportRepository.java
@@ -7,4 +7,6 @@ import java.util.Collection;
 public interface FileReportRepository {
 
   Collection<FileReport> getReportsBySenderCodes(Collection<String> senderCodes);
+
+  FileReport getReportBySenderCode(String senderCode);
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/repository/FileReportRepository.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/repository/FileReportRepository.java
@@ -9,4 +9,6 @@ public interface FileReportRepository {
   Collection<FileReport> getReportsBySenderCodes(Collection<String> senderCodes);
 
   FileReport getReportBySenderCode(String senderCode);
+
+  void save(FileReport fileReport);
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportService.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportService.java
@@ -2,12 +2,13 @@ package it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.service;
 
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
 import java.util.Collection;
+import java.util.Optional;
 
 public interface FileReportService {
 
   FileReport getAggregateFileReport(Collection<String> senderCodes);
 
-  FileReport getFileReport(String senderCode);
+  Optional<FileReport> getFileReport(String senderCode);
 
   void save(FileReport fileReport);
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportService.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportService.java
@@ -6,4 +6,6 @@ import java.util.Collection;
 public interface FileReportService {
 
   FileReport getAggregateFileReport(Collection<String> senderCodes);
+
+  FileReport getFileReport(String senderCode);
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportService.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportService.java
@@ -8,4 +8,6 @@ public interface FileReportService {
   FileReport getAggregateFileReport(Collection<String> senderCodes);
 
   FileReport getFileReport(String senderCode);
+
+  void save(FileReport fileReport);
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportService.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportService.java
@@ -5,5 +5,5 @@ import java.util.Collection;
 
 public interface FileReportService {
 
-  FileReport getFileReport(Collection<String> senderCodes);
+  FileReport getAggregateFileReport(Collection<String> senderCodes);
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportServiceImpl.java
@@ -5,6 +5,7 @@ import static it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReportAggr
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.repository.FileReportRepository;
 import java.util.Collection;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -22,7 +23,7 @@ public class FileReportServiceImpl implements FileReportService {
   }
 
   @Override
-  public FileReport getFileReport(String senderCode) {
+  public Optional<FileReport> getFileReport(String senderCode) {
     return fileReportRepository.getReportBySenderCode(senderCode);
   }
 

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportServiceImpl.java
@@ -25,4 +25,9 @@ public class FileReportServiceImpl implements FileReportService {
   public FileReport getFileReport(String senderCode) {
     return fileReportRepository.getReportBySenderCode(senderCode);
   }
+
+  @Override
+  public void save(FileReport fileReport) {
+    fileReportRepository.save(fileReport);
+  }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportServiceImpl.java
@@ -15,7 +15,7 @@ public class FileReportServiceImpl implements FileReportService {
   private final FileReportRepository fileReportRepository;
 
   @Override
-  public FileReport getFileReport(Collection<String> senderCodes) {
+  public FileReport getAggregateFileReport(Collection<String> senderCodes) {
     return fileReportRepository.getReportsBySenderCodes(senderCodes)
         .stream()
         .collect(aggregateFileReports());

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/service/FileReportServiceImpl.java
@@ -20,4 +20,9 @@ public class FileReportServiceImpl implements FileReportService {
         .stream()
         .collect(aggregateFileReports());
   }
+
+  @Override
+  public FileReport getFileReport(String senderCode) {
+    return fileReportRepository.getReportBySenderCode(senderCode);
+  }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/EventHandler.java
@@ -1,0 +1,21 @@
+package it.gov.pagopa.rtd.ms.rtdmsfilereporter.event;
+
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model.ProjectorEventDto;
+import java.util.function.Consumer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+
+/**
+ * Component defining the processing steps in response to events in the projector queue.
+ */
+@Slf4j
+@Configuration
+public class EventHandler {
+
+  @Bean
+  public Consumer<Message<ProjectorEventDto>> projectorConsumer(FileReportEventAdapter adapter) {
+    return message -> adapter.consumeEvent(message.getPayload());
+  }
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/FileReportEventAdapter.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/FileReportEventAdapter.java
@@ -1,0 +1,55 @@
+package it.gov.pagopa.rtd.ms.rtdmsfilereporter.event;
+
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.FileReportCommandFactory;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileMetadata;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.service.FileReportService;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model.EventToDomainMapper;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model.ProjectorEventDto;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Valid;
+import javax.validation.Validator;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+@Setter
+public class FileReportEventAdapter {
+
+  @Value("${report.fileTTL}")
+  private Integer fileTimeToLiveInDays;
+
+  private final FileReportService service;
+  private final Validator validator;
+  private final ModelMapper modelMapper = EventToDomainMapper.createEventDomainMapper();
+  private final FileReportCommandFactory fileReportCommandFactory;
+
+  public void consumeEvent(@Valid ProjectorEventDto eventDto) {
+    // validate dto
+    var validationErrors = validator.validate(eventDto);
+    if (!validationErrors.isEmpty()) {
+      throw new ConstraintViolationException(validationErrors);
+    }
+    log.info("Received event for file {} with status {}", eventDto.getFileName(), eventDto.getStatus().name());
+
+    // retrieve the report
+    var report = service.getFileReport(eventDto.getSender())
+        .orElse(FileReport.createFileReportWithSenderCode(eventDto.getSender()));
+
+    // execute command on report
+    fileReportCommandFactory.getCommandByStatus(eventDto.getStatus().name())
+        .accept(report, modelMapper.map(eventDto, FileMetadata.class));
+
+    // remove from the report the old files
+    report.removeFilesOlderThan(fileTimeToLiveInDays);
+
+    // save the report
+    service.save(report);
+  }
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/EventStatusEnum.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/EventStatusEnum.java
@@ -1,0 +1,9 @@
+package it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model;
+
+public enum EventStatusEnum {
+  ACK_TO_DOWNLOAD,
+  ACK_DOWNLOADED,
+  RECEIVED,
+  DECRYPTED,
+  SENT_TO_ADE
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/EventToDomainMapper.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/EventToDomainMapper.java
@@ -1,0 +1,48 @@
+package it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model;
+
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileMetadata;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileStatusEnum;
+import org.modelmapper.Converter;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeMap;
+
+public class EventToDomainMapper {
+
+  private EventToDomainMapper() {
+  }
+
+  public static ModelMapper createEventDomainMapper() {
+    ModelMapper modelMapper = new ModelMapper();
+
+    // mapping between fields
+    TypeMap<ProjectorEventDto, FileMetadata> propertyMapper = modelMapper.createTypeMap(
+        ProjectorEventDto.class, FileMetadata.class);
+    propertyMapper.addMapping(ProjectorEventDto::getFileName, FileMetadata::setName);
+    propertyMapper.addMapping(ProjectorEventDto::getReceiveTimestamp,
+        FileMetadata::setTransmissionDate);
+
+    // mapping from event status to domain status
+    Converter<EventStatusEnum, FileStatusEnum> mapStatus = context -> convertFromStringToStatusEnum(
+        context.getSource());
+    propertyMapper.addMappings(mapper -> mapper.using(mapStatus)
+        .map(ProjectorEventDto::getStatus, FileMetadata::setStatus));
+
+    return modelMapper;
+  }
+
+  private static FileStatusEnum convertFromStringToStatusEnum(EventStatusEnum status) {
+    switch (status) {
+      case RECEIVED:
+        return FileStatusEnum.RECEIVED_BY_PAGOPA;
+      case DECRYPTED:
+        return FileStatusEnum.VALIDATED_BY_PAGOPA;
+      case SENT_TO_ADE:
+        return FileStatusEnum.SENT_TO_AGENZIA_DELLE_ENTRATE;
+      case ACK_DOWNLOADED:
+        return FileStatusEnum.ACK_DOWNLOADED;
+      case ACK_TO_DOWNLOAD:
+        return FileStatusEnum.ACK_TO_DOWNLOAD;
+    }
+    return null;
+  }
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/ProjectorEventDto.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/ProjectorEventDto.java
@@ -33,14 +33,4 @@ public class ProjectorEventDto {
 
   @NotNull
   private EventStatusEnum status;
-
-  @Override
-  public String toString() {
-    return "EventDto{" +
-        "parent='" + fileName + '\'' +
-        ", sender='" + sender + '\'' +
-        ", size=" + size +
-        ", receiveTimestamp=" + receiveTimestamp +
-        '}';
-  }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/ProjectorEventDto.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/ProjectorEventDto.java
@@ -1,0 +1,46 @@
+package it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import java.time.LocalDateTime;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ProjectorEventDto {
+
+  @NotNull
+  @NotBlank
+  private String fileName;
+
+  @NotNull
+  @NotBlank
+  private String sender;
+
+  private Long size;
+
+  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+  private LocalDateTime receiveTimestamp;
+
+  @NotNull
+  private EventStatusEnum status;
+
+  @Override
+  public String toString() {
+    return "EventDto{" +
+        "parent='" + fileName + '\'' +
+        ", sender='" + sender + '\'' +
+        ", size=" + size +
+        ", receiveTimestamp=" + receiveTimestamp +
+        '}';
+  }
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportDao.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportDao.java
@@ -2,9 +2,12 @@ package it.gov.pagopa.rtd.ms.rtdmsfilereporter.persistance;
 
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.persistance.model.FileReportEntity;
 import java.util.Collection;
+import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface FileReportDao extends MongoRepository<FileReportEntity, String> {
 
   Collection<FileReportEntity> findBySenderCodeIn(Collection<String> senderCodes);
+
+  Optional<FileReportEntity> findBySenderCode(String senderCode);
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImpl.java
@@ -2,6 +2,7 @@ package it.gov.pagopa.rtd.ms.rtdmsfilereporter.persistance;
 
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.repository.FileReportRepository;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.persistance.model.FileReportEntity;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
@@ -31,5 +32,10 @@ public class FileReportRepositoryImpl implements FileReportRepository {
     return fileReportDao.findBySenderCode(senderCode)
         .map(entity -> modelMapper.map(entity, FileReport.class))
         .orElse(FileReport.createFileReport());
+  }
+
+  @Override
+  public void save(FileReport fileReport) {
+    fileReportDao.save(modelMapper.map(fileReport, FileReportEntity.class));
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImpl.java
@@ -25,4 +25,11 @@ public class FileReportRepositoryImpl implements FileReportRepository {
           .collect(Collectors.toList());
     }
   }
+
+  @Override
+  public FileReport getReportBySenderCode(String senderCode) {
+    return fileReportDao.findBySenderCode(senderCode)
+        .map(entity -> modelMapper.map(entity, FileReport.class))
+        .orElse(FileReport.createFileReport());
+  }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImpl.java
@@ -5,6 +5,7 @@ import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.repository.FileReportReposi
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.persistance.model.FileReportEntity;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -28,10 +29,9 @@ public class FileReportRepositoryImpl implements FileReportRepository {
   }
 
   @Override
-  public FileReport getReportBySenderCode(String senderCode) {
+  public Optional<FileReport> getReportBySenderCode(String senderCode) {
     return fileReportDao.findBySenderCode(senderCode)
-        .map(entity -> modelMapper.map(entity, FileReport.class))
-        .orElse(FileReport.createFileReport());
+        .map(entity -> modelMapper.map(entity, FileReport.class));
   }
 
   @Override

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/model/FileReportEntityMapper.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/model/FileReportEntityMapper.java
@@ -17,7 +17,7 @@ public class FileReportEntityMapper {
     Converter<String, Collection<String>> stringToCollection = c -> Collections.singleton(
         c.getSource());
     Converter<Collection<String>, String> collectionToString = c -> c.getSource().stream()
-        .findFirst().orElse(null);
+        .findAny().orElse(null);
 
     var propertyMapperEntityToDomain = modelMapper.createTypeMap(
         FileReportEntity.class, FileReport.class);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,8 @@
+topics:
+  rtd-projector:
+    topic: ${KAFKA_RTD_PROJECTOR_TOPIC:rtd-projector}
+    group: ${KAFKA_RTD_PROJECTOR_CONSUMER_GROUP:rtd-file-reporter-consumer-group}
+
 spring:
   config:
     activate:
@@ -6,3 +11,32 @@ spring:
     mongodb:
       uri: ${MONGODB_CONNECTION_URI:mongodb://localhost:27017}
       database: ${MONGODB_NAME:rtd}
+  cloud:
+    stream:
+      bindings:
+        projectorConsumer-in-0: # name must match [handler name]-in-0
+          destination: ${topics.rtd-projector.topic}
+          group: ${topics.rtd-projector.group}
+          content-type: application/json
+          binder: projector
+          consumer:
+            max-attempts: 1
+
+      kafka:
+        binder:
+          configuration:
+            security.protocol: SASL_SSL
+            sasl.mechanism: PLAIN
+
+      binders:
+        projector:
+          type: kafka
+          environment.spring.cloud.stream.kafka:
+            binder:
+              auto-create-topics: false
+              brokers: ${KAFKA_RTD_PROJECTOR_BROKER:localhost:29095}
+              configuration:
+                sasl.jaas.config: ${KAFKA_RTD_PROJECTOR_SASL_JAAS_CONFIG}
+              consumerProperties:
+                key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+                value.deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,9 @@ topics:
     topic: ${KAFKA_RTD_PROJECTOR_TOPIC:rtd-projector}
     group: ${KAFKA_RTD_PROJECTOR_CONSUMER_GROUP:rtd-file-reporter-consumer-group}
 
+report:
+  fileTTL: ${FILE_TTL_IN_DAYS:15}
+
 spring:
   config:
     activate:

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/config/KafkaTestConfiguration.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/config/KafkaTestConfiguration.java
@@ -1,0 +1,12 @@
+package it.gov.pagopa.rtd.ms.rtdmsfilereporter.config;
+
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.persistance.FileReportDao;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@TestConfiguration
+public class KafkaTestConfiguration {
+
+  @MockBean
+  private FileReportDao dao;
+}

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/FileReportControllerImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/FileReportControllerImplTest.java
@@ -24,7 +24,6 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -48,7 +47,8 @@ class FileReportControllerImplTest {
   @SneakyThrows
   @Test
   void givenEmptyReportWhenGetFileReportThenReturnEmptyListJson() {
-    Mockito.when(fileReportService.getFileReport(any())).thenReturn(FileReport.createFileReport());
+    Mockito.when(fileReportService.getAggregateFileReport(any()))
+        .thenReturn(FileReport.createFileReport());
 
     FileReportDto fileReportDto = new FileReportDto();
     fileReportDto.setFilesRecentlyUploaded(new HashSet<>());
@@ -65,7 +65,7 @@ class FileReportControllerImplTest {
   @SneakyThrows
   @Test
   void givenReportWhenGetFileReportThenReturnCorrectJson() {
-    Mockito.when(fileReportService.getFileReport(any()))
+    Mockito.when(fileReportService.getAggregateFileReport(any()))
         .thenReturn(TestUtils.createFileReport(2, 2));
 
     MvcResult result = mockMvc.perform(
@@ -82,7 +82,8 @@ class FileReportControllerImplTest {
   @SneakyThrows
   @Test
   void givenNoQueryParamsWhenGetFileReportThenReturn400() {
-    Mockito.when(fileReportService.getFileReport(any())).thenReturn(FileReport.createFileReport());
+    Mockito.when(fileReportService.getAggregateFileReport(any()))
+        .thenReturn(FileReport.createFileReport());
 
     mockMvc.perform(MockMvcRequestBuilders.get(FILE_REPORT_URL))
         .andExpect(status().isBadRequest())

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/FileReportControllerImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/FileReportControllerImplTest.java
@@ -12,6 +12,7 @@ import it.gov.pagopa.rtd.ms.rtdmsfilereporter.controller.model.FileReportDto;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.controller.model.FileReportDtoMapper;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileMetadata;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileStatusEnum;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.service.FileReportService;
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -94,7 +95,7 @@ class FileReportControllerImplTest {
   void mappingFromDomainToDtoWorksCorrectly() {
     var currentDate = LocalDateTime.now();
     FileReport fileReport = FileReport.createFileReport();
-    FileMetadata fileMetadata = new FileMetadata("file", 3000L, "STATUS", currentDate);
+    FileMetadata fileMetadata = new FileMetadata("file", 3000L, FileStatusEnum.RECEIVED_BY_PAGOPA, currentDate);
     fileReport.addFileUploaded(fileMetadata);
     fileReport.addAckToDownload("ack1");
     fileReport.setSenderCodes(List.of("senderCode"));
@@ -108,6 +109,6 @@ class FileReportControllerImplTest {
             FileMetadataDto::getStatus,
             FileMetadataDto::getTransmissionDate)
         .doesNotContainNull()
-        .containsExactly(Tuple.tuple("file", 3000L, "STATUS", currentDate));
+        .containsExactly(Tuple.tuple("file", 3000L, FileStatusEnum.RECEIVED_BY_PAGOPA.name(), currentDate));
   }
 }

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/EventHandlerTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/EventHandlerTest.java
@@ -1,0 +1,86 @@
+package it.gov.pagopa.rtd.ms.rtdmsfilereporter.event;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.config.KafkaTestConfiguration;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model.EventStatusEnum;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model.ProjectorEventDto;
+import java.time.LocalDateTime;
+import java.util.function.Consumer;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.context.annotation.Import;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.messaging.Message;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@EnableAutoConfiguration(exclude = {EmbeddedMongoAutoConfiguration.class,
+    MongoAutoConfiguration.class, MongoDataAutoConfiguration.class})
+@ActiveProfiles("kafka-test")
+@EmbeddedKafka(topics = {
+    "${test.kafka.topic}"}, partitions = 1, bootstrapServersProperty = "spring.embedded.kafka.brokers")
+@Import(KafkaTestConfiguration.class)
+class EventHandlerTest {
+
+  @Value("${test.kafka.topic}")
+  private String topic;
+  @Autowired
+  private StreamBridge stream;
+  @Autowired
+  private EmbeddedKafkaBroker broker;
+  @MockBean
+  private Consumer<Message<ProjectorEventDto>> projectorConsumer;
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void setUp() {
+  }
+
+  @AfterEach
+  void tearDown() {
+  }
+
+  @SneakyThrows
+  @Test
+  void whenACorrectEventIsSentThenConsumeIt() {
+    var currentDate = LocalDateTime.now();
+    var eventDto = new ProjectorEventDto("prova", "Sender", 100L, currentDate,
+        EventStatusEnum.RECEIVED);
+
+    stream.send("projectorConsumer-in-0", MessageBuilder.withPayload(eventDto).build());
+
+    verify(projectorConsumer, times(1)).accept(any());
+  }
+
+  @SneakyThrows
+  @Test
+  void whenAMalformedEventIsSentThenRaiseException() {
+    var currentDate = LocalDateTime.now();
+    String eventDtoJson =
+        "{\"fileName\": \"prova\", \"sender\": \"Sender\", \"size\":100, \"receiveTimestamp\": \"" +
+            currentDate + "\", \"status\": \"UNMAPPED\"}";
+
+    assertThatThrownBy(() -> objectMapper.readValue(eventDtoJson, ProjectorEventDto.class))
+        .isInstanceOf(InvalidFormatException.class);
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/FileReportEventAdapterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/FileReportEventAdapterTest.java
@@ -1,0 +1,192 @@
+package it.gov.pagopa.rtd.ms.rtdmsfilereporter.event;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.FileReportCommandFactory;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileMetadata;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileStatusEnum;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.service.FileReportService;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model.EventStatusEnum;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model.ProjectorEventDto;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Optional;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+class FileReportEventAdapterTest {
+
+  @Mock
+  private FileReportService service;
+  private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+  private FileReportEventAdapter adapter;
+  private AutoCloseable autoCloseable;
+  private final int fileTTL = 10;
+
+  @BeforeEach
+  void setUp() {
+    autoCloseable = MockitoAnnotations.openMocks(this);
+    adapter = new FileReportEventAdapter(service, validator, new FileReportCommandFactory());
+    adapter.setFileTimeToLiveInDays(fileTTL);
+  }
+
+  @SneakyThrows
+  @AfterEach
+  void tearDown() {
+    autoCloseable.close();
+  }
+
+  @Test
+  void whenReceiveAMalformedEventThenRaiseException() {
+    ProjectorEventDto eventDto = new ProjectorEventDto("file", null, 100L, LocalDateTime.now(),
+        EventStatusEnum.RECEIVED);
+
+    assertThatThrownBy(() -> adapter.consumeEvent(eventDto)).isInstanceOf(
+        ConstraintViolationException.class);
+  }
+
+  @Test
+  void whenReceiveAnEventThenAddFileToEmptyReport() {
+    Mockito.when(service.getFileReport(any())).thenReturn(Optional.empty());
+
+    var currentDate = LocalDateTime.now();
+    ProjectorEventDto eventDto = new ProjectorEventDto("file", "12345", 100L, currentDate,
+        EventStatusEnum.RECEIVED);
+    FileReport expectedReport = FileReport.createFileReport();
+    expectedReport.setSenderCodes(Collections.singleton("12345"));
+    expectedReport.addFileUploaded(
+        new FileMetadata("file", 100L, FileStatusEnum.RECEIVED_BY_PAGOPA, currentDate));
+
+    adapter.consumeEvent(eventDto);
+
+    verify(service).getFileReport("12345");
+    verify(service).save(expectedReport);
+  }
+
+  @Test
+  void whenReceiveAnEventThenChangeStatusToFile() {
+    var currentDate = LocalDateTime.now();
+    FileReport reportToBeRead = FileReport.createFileReport();
+    reportToBeRead.addFileUploaded(
+        new FileMetadata("file", 100L, FileStatusEnum.RECEIVED_BY_PAGOPA, currentDate));
+    Mockito.when(service.getFileReport(any())).thenReturn(Optional.of(reportToBeRead));
+
+    // even if other fields are different, the only field that will be changed is "status"
+    ProjectorEventDto eventDto = new ProjectorEventDto("file", "12345", 300L, LocalDateTime.now(),
+        EventStatusEnum.DECRYPTED);
+    FileReport expectedReport = FileReport.createFileReport();
+    expectedReport.addFileUploaded(
+        new FileMetadata("file", 100L, FileStatusEnum.VALIDATED_BY_PAGOPA, currentDate));
+
+    adapter.consumeEvent(eventDto);
+
+    verify(service).getFileReport("12345");
+    verify(service).save(expectedReport);
+  }
+
+  @Test
+  void whenReceiveAnEventThenRemoveOldFile() {
+    var currentDate = LocalDateTime.now();
+    FileReport reportToBeRead = FileReport.createFileReport();
+    reportToBeRead.addFileUploaded(
+        new FileMetadata("file", 100L, FileStatusEnum.RECEIVED_BY_PAGOPA,
+            currentDate.minusDays(fileTTL + 1)));
+    Mockito.when(service.getFileReport(any())).thenReturn(Optional.of(reportToBeRead));
+
+    ProjectorEventDto eventDto = new ProjectorEventDto("newFile", "12345", 300L, currentDate,
+        EventStatusEnum.RECEIVED);
+    FileReport expectedReport = FileReport.createFileReport();
+    expectedReport.addFileUploaded(
+        new FileMetadata("newFile", 300L, FileStatusEnum.RECEIVED_BY_PAGOPA, currentDate));
+
+    adapter.consumeEvent(eventDto);
+
+    verify(service).getFileReport("12345");
+    verify(service).save(expectedReport);
+  }
+
+  @Test
+  void whenReceiveAnEventThenAddNewFile() {
+    var currentDate = LocalDateTime.now();
+    FileReport reportToBeRead = FileReport.createFileReport();
+    reportToBeRead.addFileUploaded(
+        new FileMetadata("file", 100L, FileStatusEnum.RECEIVED_BY_PAGOPA, currentDate));
+    Mockito.when(service.getFileReport(any())).thenReturn(Optional.of(reportToBeRead));
+
+    ProjectorEventDto eventDto = new ProjectorEventDto("newFile", "12345", 300L, currentDate,
+        EventStatusEnum.SENT_TO_ADE);
+    FileReport expectedReport = FileReport.createFileReport();
+    expectedReport.addFileUploaded(
+        new FileMetadata("newFile", 300L, FileStatusEnum.SENT_TO_AGENZIA_DELLE_ENTRATE, currentDate));
+    expectedReport.addFileUploaded(
+        new FileMetadata("file", 100L, FileStatusEnum.RECEIVED_BY_PAGOPA, currentDate));
+
+    adapter.consumeEvent(eventDto);
+
+    verify(service).getFileReport("12345");
+    verify(service).save(expectedReport);
+  }
+
+  @Test
+  void whenReceiveAnACKEventThenAddNewAckToEmptyReport() {
+    var currentDate = LocalDateTime.now();
+    Mockito.when(service.getFileReport(any())).thenReturn(Optional.empty());
+
+    ProjectorEventDto eventDto = new ProjectorEventDto("ackFile", "12345", 300L, currentDate,
+        EventStatusEnum.ACK_TO_DOWNLOAD);
+    FileReport expectedReport = FileReport.createFileReport();
+    expectedReport.addSenderCode("12345");
+    expectedReport.addAckToDownload("ackFile");
+
+    adapter.consumeEvent(eventDto);
+
+    verify(service).getFileReport("12345");
+    verify(service).save(expectedReport);
+  }
+
+  @Test
+  void whenReceiveAnACKEventThenRemoveAckFromCollection() {
+    var currentDate = LocalDateTime.now();
+    FileReport reportToBeRead = FileReport.createFileReport();
+    reportToBeRead.addAckToDownload("ackToDownload");
+    Mockito.when(service.getFileReport(any())).thenReturn(Optional.of(reportToBeRead));
+
+    ProjectorEventDto eventDto = new ProjectorEventDto("ackToDownload", "12345", 300L, currentDate,
+        EventStatusEnum.ACK_DOWNLOADED);
+    FileReport expectedReport = FileReport.createFileReport();
+
+    adapter.consumeEvent(eventDto);
+
+    verify(service).getFileReport("12345");
+    verify(service).save(expectedReport);
+  }
+
+  @Test
+  void whenReceiveStatusNotMappedThenThrowException() {
+    Mockito.when(service.getFileReport(any())).thenReturn(Optional.empty());
+
+    var currentDate = LocalDateTime.now();
+    ProjectorEventDto eventDto = new ProjectorEventDto("file", "12345", 100L, currentDate,
+        EventStatusEnum.RECEIVED);
+    FileReport expectedReport = FileReport.createFileReport();
+    expectedReport.addSenderCode("12345");
+    expectedReport.addFileUploaded(
+        new FileMetadata("file", 100L, FileStatusEnum.RECEIVED_BY_PAGOPA, currentDate));
+
+    adapter.consumeEvent(eventDto);
+
+    verify(service).getFileReport("12345");
+    verify(service).save(expectedReport);
+  }
+}

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/EventToDomainMapperTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/EventToDomainMapperTest.java
@@ -1,0 +1,45 @@
+package it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileMetadata;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileStatusEnum;
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.modelmapper.ModelMapper;
+
+class EventToDomainMapperTest {
+
+  private final ModelMapper modelMapper = EventToDomainMapper.createEventDomainMapper();
+
+  private static Stream<Arguments> provideStatus() {
+    return Stream.of(
+        Arguments.of(EventStatusEnum.RECEIVED, FileStatusEnum.RECEIVED_BY_PAGOPA),
+        Arguments.of(EventStatusEnum.DECRYPTED, FileStatusEnum.VALIDATED_BY_PAGOPA),
+        Arguments.of(EventStatusEnum.SENT_TO_ADE, FileStatusEnum.SENT_TO_AGENZIA_DELLE_ENTRATE),
+        Arguments.of(EventStatusEnum.ACK_TO_DOWNLOAD, FileStatusEnum.ACK_TO_DOWNLOAD),
+        Arguments.of(EventStatusEnum.ACK_DOWNLOADED, FileStatusEnum.ACK_DOWNLOADED)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideStatus")
+  void mappingFromEventToDomainWorksCorrectly(EventStatusEnum eventStatus,
+      FileStatusEnum domainStatus) {
+    var currentDate = LocalDateTime.now();
+    var eventDto = new ProjectorEventDto("filename", "12345", 100L, currentDate,
+        eventStatus);
+
+    var domainFile = modelMapper.map(eventDto, FileMetadata.class);
+
+    assertThat(domainFile).isNotNull();
+    assertThat(domainFile.getName()).isEqualTo("filename");
+    assertThat(domainFile.getStatus()).isEqualTo(domainStatus);
+    assertThat(domainFile.getSize()).isEqualTo(100L);
+    assertThat(domainFile.getTransmissionDate()).isEqualTo(currentDate);
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImplTest.java
@@ -116,6 +116,16 @@ class FileReportRepositoryImplTest {
     assertThat(fileReport.getId()).isNotNull().isEqualTo("testID");
   }
 
+  @Test
+  void whenSaveReportThenSaveIt() {
+    var reportStub = TestUtils.createFileReport(1, 1);
+    reportStub.setSenderCodes(Collections.singleton("12345"));
+
+    repository.save(reportStub);
+
+    verify(dao).save(modelMapper.map(reportStub, FileReportEntity.class));
+  }
+
   Collection<FileReportEntity> getMockedReports() {
     var reports = new ArrayList<FileReportEntity>();
     reports.add(modelMapper.map(TestUtils.createFileReport(1, 1), FileReportEntity.class));

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.TestUtils;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileMetadata;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileStatusEnum;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.repository.FileReportRepository;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.persistance.model.FileReportEntity;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.persistance.model.FileReportEntityMapper;
@@ -75,10 +76,7 @@ class FileReportRepositoryImplTest {
 
     var fileReport = repository.getReportBySenderCode("12345");
 
-    assertThat(fileReport).isNotNull();
-    assertThat(fileReport.getAckToDownload()).isNotNull().isEmpty();
-    assertThat(fileReport.getFilesUploaded()).isNotNull().isEmpty();
-    assertThat(fileReport.getSenderCodes()).isNotNull().isEmpty();
+    assertThat(fileReport).isEmpty();
   }
 
   @Test
@@ -90,10 +88,10 @@ class FileReportRepositoryImplTest {
 
     var fileReport = repository.getReportBySenderCode("12345");
 
-    assertThat(fileReport).isNotNull();
-    assertThat(fileReport.getAckToDownload()).isNotNull().hasSize(1);
-    assertThat(fileReport.getFilesUploaded()).isNotNull().hasSize(1);
-    assertThat(fileReport.getSenderCodes()).isNotNull().contains("12345");
+    assertThat(fileReport).isNotEmpty();
+    assertThat(fileReport.get().getAckToDownload()).isNotNull().hasSize(1);
+    assertThat(fileReport.get().getFilesUploaded()).isNotNull().hasSize(1);
+    assertThat(fileReport.get().getSenderCodes()).isNotNull().contains("12345");
   }
 
   @Test
@@ -102,7 +100,7 @@ class FileReportRepositoryImplTest {
     FileReportEntity fileReportEntity = new FileReportEntity();
     fileReportEntity.setSenderCode("12345");
     fileReportEntity.setFilesUploaded(
-        List.of(new FileMetadata("file", 200L, "STATUS", currentDate)));
+        List.of(new FileMetadata("file", 200L, FileStatusEnum.RECEIVED_BY_PAGOPA, currentDate)));
     fileReportEntity.setAckToDownload(List.of("ack1", "ack2"));
     fileReportEntity.setId("testID");
 
@@ -110,7 +108,8 @@ class FileReportRepositoryImplTest {
 
     assertThat(fileReport).isNotNull();
     assertThat(fileReport.getFilesUploaded()).isNotNull().hasSize(1)
-        .containsExactly(new FileMetadata("file", 200L, "STATUS", currentDate));
+        .containsExactly(
+            new FileMetadata("file", 200L, FileStatusEnum.RECEIVED_BY_PAGOPA, currentDate));
     assertThat(fileReport.getAckToDownload()).isNotNull().hasSize(2).contains("ack1", "ack2");
     assertThat(fileReport.getSenderCodes()).isNotNull().hasSize(1).contains("12345");
     assertThat(fileReport.getId()).isNotNull().isEqualTo("testID");

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImplTest.java
@@ -2,6 +2,7 @@ package it.gov.pagopa.rtd.ms.rtdmsfilereporter.persistance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.TestUtils;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileMetadata;
@@ -14,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,6 +67,33 @@ class FileReportRepositoryImplTest {
     var fileReports = repository.getReportsBySenderCodes(any());
 
     assertThat(fileReports).isNotNull().hasSize(2);
+  }
+
+  @Test
+  void givenNoReportWhenGetReportThenReturnEmptyReport() {
+    Mockito.when(dao.findBySenderCode("12345")).thenReturn(Optional.empty());
+
+    var fileReport = repository.getReportBySenderCode("12345");
+
+    assertThat(fileReport).isNotNull();
+    assertThat(fileReport.getAckToDownload()).isNotNull().isEmpty();
+    assertThat(fileReport.getFilesUploaded()).isNotNull().isEmpty();
+    assertThat(fileReport.getSenderCodes()).isNotNull().isEmpty();
+  }
+
+  @Test
+  void whenGetReportThenReturnAReport() {
+    var reportStub = TestUtils.createFileReport(1, 1);
+    reportStub.setSenderCodes(Collections.singleton("12345"));
+    Mockito.when(dao.findBySenderCode("12345")).thenReturn(
+        Optional.of(modelMapper.map(reportStub, FileReportEntity.class)));
+
+    var fileReport = repository.getReportBySenderCode("12345");
+
+    assertThat(fileReport).isNotNull();
+    assertThat(fileReport.getAckToDownload()).isNotNull().hasSize(1);
+    assertThat(fileReport.getFilesUploaded()).isNotNull().hasSize(1);
+    assertThat(fileReport.getSenderCodes()).isNotNull().contains("12345");
   }
 
   @Test

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/service/FileReportServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/service/FileReportServiceImplTest.java
@@ -3,6 +3,7 @@ package it.gov.pagopa.rtd.ms.rtdmsfilereporter.service;
 import static it.gov.pagopa.rtd.ms.rtdmsfilereporter.TestUtils.createFileReport;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.repository.FileReportRepository;
@@ -75,6 +76,13 @@ class FileReportServiceImplTest {
     assertThat(filereport).isNotNull();
     assertThat(filereport.getFilesUploaded()).isNotNull().isEmpty();
     assertThat(filereport.getAckToDownload()).isNotNull().isEmpty();
+  }
+
+  @Test
+  void whenSaveThenRepositorySaveIsInvoked() {
+    fileReportService.save(FileReport.createFileReport());
+
+    verify(fileReportRepository).save(FileReport.createFileReport());
   }
 
   Collection<FileReport> getReportList() {

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/service/FileReportServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/service/FileReportServiceImplTest.java
@@ -65,6 +65,18 @@ class FileReportServiceImplTest {
     assertThat(filereport.getAckToDownload()).isNotNull().isEmpty();
   }
 
+  @Test
+  void whenGetFileReportThenReturnsAReport() {
+    Mockito.when(fileReportRepository.getReportBySenderCode(any()))
+        .thenReturn(FileReport.createFileReport());
+
+    FileReport filereport = fileReportService.getFileReport("12345");
+
+    assertThat(filereport).isNotNull();
+    assertThat(filereport.getFilesUploaded()).isNotNull().isEmpty();
+    assertThat(filereport.getAckToDownload()).isNotNull().isEmpty();
+  }
+
   Collection<FileReport> getReportList() {
     return Stream.of(createFileReport(3, 1), createFileReport(1, 2), createFileReport(2, 1))
         .collect(Collectors.toList());

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/service/FileReportServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/service/FileReportServiceImplTest.java
@@ -11,6 +11,7 @@ import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.service.FileReportService;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.service.FileReportServiceImpl;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
@@ -69,13 +70,11 @@ class FileReportServiceImplTest {
   @Test
   void whenGetFileReportThenReturnsAReport() {
     Mockito.when(fileReportRepository.getReportBySenderCode(any()))
-        .thenReturn(FileReport.createFileReport());
+        .thenReturn(Optional.empty());
 
-    FileReport filereport = fileReportService.getFileReport("12345");
+    var filereport = fileReportService.getFileReport("12345");
 
-    assertThat(filereport).isNotNull();
-    assertThat(filereport.getFilesUploaded()).isNotNull().isEmpty();
-    assertThat(filereport.getAckToDownload()).isNotNull().isEmpty();
+    assertThat(filereport).isEmpty();
   }
 
   @Test

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/service/FileReportServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/service/FileReportServiceImplTest.java
@@ -44,7 +44,8 @@ class FileReportServiceImplTest {
   void whenGetFileReportForManySenderCodesThenMergeTheReportsCorrectly() {
     Mockito.when(fileReportRepository.getReportsBySenderCodes(any())).thenReturn(getReportList());
 
-    FileReport filereport = fileReportService.getFileReport(Collections.singleton("12345"));
+    FileReport filereport = fileReportService.getAggregateFileReport(
+        Collections.singleton("12345"));
 
     assertThat(filereport).isNotNull();
     assertThat(filereport.getFilesUploaded()).isNotNull().hasSize(4);
@@ -56,7 +57,8 @@ class FileReportServiceImplTest {
     Mockito.when(fileReportRepository.getReportsBySenderCodes(any()))
         .thenReturn(Collections.emptyList());
 
-    FileReport filereport = fileReportService.getFileReport(Collections.singleton("12345"));
+    FileReport filereport = fileReportService.getAggregateFileReport(
+        Collections.singleton("12345"));
 
     assertThat(filereport).isNotNull();
     assertThat(filereport.getFilesUploaded()).isNotNull().isEmpty();

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,1 +1,39 @@
 spring.mongodb.embedded.version: 5.0.0
+
+report:
+  fileTTL: ${FILE_TTL_IN_DAYS:15}
+
+---
+
+test.kafka.topic: rtd-projector
+
+spring:
+  config:
+    activate:
+      on-profile: kafka-test
+
+  cloud:
+    stream:
+      bindings:
+        projectorConsumer-in-0: # name must match [handler name]-in-0
+          destination: ${test.kafka.topic}
+          group: projector-consumer-group
+          content-type: application/json
+          binder: projector
+          consumer:
+            max-attempts: 1
+
+      binders:
+        projector:
+          type: kafka
+          environment.spring.cloud.stream.kafka:
+            binder:
+              auto-create-topics: false
+              brokers: ${spring.embedded.kafka.brokers}
+              sync: true
+              requiredAcks: all
+              configuration:
+                sasl.jaas.config: ${KAFKA_RTD_PROJECTOR_SASL_JAAS_CONFIG}
+              consumerProperties:
+                key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+                value.deserializer: org.apache.kafka.common.serialization.StringDeserializer


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to merge into dev branch the command related part of CQRS pattern.

#### List of Changes

<!--- Describe your changes in detail -->
- add queue connection
- add consumer
- update domain model to support changed triggered by queue events
- add status mapping

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The file reporter to achieve its goal must receive events from a projector queue and update his data model accordingly. In order to do that a consumer has been added capable of receiving the event and propagate the changes into the cosmos db.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Chore change (non-breaking change which doesn't provide a direct value to users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
