### PR TITLE
feat: [RTD-1046] order files inside report by date descending

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileMetadata.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileMetadata.java
@@ -13,7 +13,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 @AllArgsConstructor
 @NoArgsConstructor
 @EqualsAndHashCode
-public class FileMetadata {
+public class FileMetadata implements Comparable<FileMetadata> {
 
   @NotNull
   @NotBlank
@@ -34,5 +34,17 @@ public class FileMetadata {
 
   public static FileMetadata createNewFileMetadataWithStatus(String name, FileStatusEnum status) {
     return new FileMetadata(name, null, status, LocalDateTime.now());
+  }
+
+  /**
+   * Descending ordering for transmissionDate. The files will be ordered from the most recent to the
+   * oldest.
+   *
+   * @param o the object to be compared.
+   * @return result of compare.
+   */
+  @Override
+  public int compareTo(@org.jetbrains.annotations.NotNull FileMetadata o) {
+    return o.getTransmissionDate().compareTo(this.transmissionDate);
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileMetadata.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileMetadata.java
@@ -44,7 +44,7 @@ public class FileMetadata implements Comparable<FileMetadata> {
    * @return result of compare.
    */
   @Override
-  public int compareTo(@org.jetbrains.annotations.NotNull FileMetadata o) {
+  public int compareTo(@NotNull FileMetadata o) {
     return o.getTransmissionDate().compareTo(this.transmissionDate);
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileReport.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileReport.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.TreeSet;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -66,7 +67,7 @@ public class FileReport {
   }
 
   public static FileReport createFileReport() {
-    return new FileReport(null, new HashSet<>(), new HashSet<>(), new HashSet<>());
+    return new FileReport(null, new HashSet<>(), new TreeSet<>(), new HashSet<>());
   }
 
   public static FileReport createFileReportWithSenderCode(String senderCode) {

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileReportTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/model/FileReportTest.java
@@ -20,16 +20,20 @@ class FileReportTest {
   }
 
   @Test
-  void whenAddFileUploadedThenCollectionIsUpdatedCorrectly() {
+  void whenAddFileUploadedThenCollectionIsUpdatedAndSortedCorrectly() {
     FileReport fileReport = FileReport.createFileReport();
 
-    fileReport.addFileUploaded(FileMetadata.createNewFileMetadata("file1"));
+    fileReport.addFileUploaded(
+        new FileMetadata("oldestFile", 200L, FileStatusEnum.RECEIVED_BY_PAGOPA,
+            LocalDateTime.of(2022, 1, 1, 10, 0)));
     assertThat(fileReport.getFilesUploaded()).isNotNull().hasSize(1)
-        .map(FileMetadata::getName).contains("file1");
+        .map(FileMetadata::getName).contains("oldestFile");
 
-    fileReport.addFileUploaded(FileMetadata.createNewFileMetadata("file2"));
+    fileReport.addFileUploaded(
+        new FileMetadata("mostRecentFile", 200L, FileStatusEnum.RECEIVED_BY_PAGOPA,
+            LocalDateTime.of(2022, 1, 2, 10, 0)));
     assertThat(fileReport.getFilesUploaded()).isNotNull().hasSize(2)
-        .map(FileMetadata::getName).contains("file1", "file2");
+        .map(FileMetadata::getName).containsExactly("mostRecentFile", "oldestFile");
   }
 
   @Test


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to introduce a sorting in the file collection inside the report. The files will be sorted by descending date.

#### List of Changes

<!--- Describe your changes in detail -->
- Implement `Comparable` interface
- Change data structure from `HashSet` to `TreeSet`
- update unit tests

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The report is more meaningful if shows the files from the most recent one to the oldest. 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Chore change (non-breaking change which doesn't provide a direct value to users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
