### PR TITLE
fix: [RTD-2299] Reduce OpenTelemetry Truncation log level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>it.gov.pagopa.rtd.ms</groupId>
 	<artifactId>rtd-ms-file-reporter</artifactId>
-	<version>1.3.1</version>
+	<version>1.3.3</version>
 	<name>rtd-ms-file-reporter</name>
 	<description>Micro-service to retrieve and keep updated the file reports for senders</description>
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,7 @@ logging:
   level:
     root: INFO
     org.apache.kafka: WARN
+    com.azure.monitor.opentelemetry.exporter.implementation.builders.TelemetryTruncation: ERROR
 
 # OpenTelemetry
 applicationinsights.enabled: '@applicationinsights.enabled@'


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to reduce OpenTelemetry Truncation log level threshold to ERROR.
#### List of Changes
- change OpenTelemetry Truncation log level in `application.yml`
<!--- Describe your changes in detail -->

#### Motivation and Context
With this change we avoid warnings for truncated logs sent to Application Insights by OpenTelemetry.
The logs are referred to anonymized Mongo operations, thus we don't need either the complete log and the warning.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [x] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore change (non-breaking change which doesn't provide a direct value to users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
