### PR TITLE
fix: [RTD-2345] replace modelmapper with mapstruct

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
 		<spring-cloud.version>2023.0.0</spring-cloud.version>
 		<testcontainers.version>1.19.3</testcontainers.version>
 		<snakeyaml.version>2.2</snakeyaml.version>
-		<modelmapper.version>3.2.0</modelmapper.version>
 		<kafka.version>3.6.1</kafka.version>
 		<sonar.exclusions>**/telemetry/**.java</sonar.exclusions>
 		<applicationinsights.enabled>true</applicationinsights.enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
 		<kafka.version>3.6.1</kafka.version>
 		<sonar.exclusions>**/telemetry/**.java</sonar.exclusions>
 		<applicationinsights.enabled>true</applicationinsights.enabled>
+		<org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
 	</properties>
 
 	<dependencies>
@@ -51,12 +52,12 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<optional>true</optional>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.modelmapper</groupId>
-			<artifactId>modelmapper</artifactId>
-			<version>${modelmapper.version}</version>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>${org.mapstruct.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -155,16 +156,26 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>${project.parent.version}</version>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<excludes>
-						<exclude>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${org.mapstruct.version}</version>
+						</path>
+						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
+							<version>${lombok.version}</version>
+						</path>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok-mapstruct-binding</artifactId>
+							<version>0.2.0</version>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/configuration/AppConfiguration.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/configuration/AppConfiguration.java
@@ -23,8 +23,8 @@ public class AppConfiguration {
   }
 
   @Bean
-  public FileReportRepository getFileReportRepository(FileReportDao dao) {
-    return new FileReportRepositoryImpl(dao, FileReportEntityMapper.createEntityDomainMapper());
+  public FileReportRepository getFileReportRepository(FileReportDao dao, FileReportEntityMapper mapper) {
+    return new FileReportRepositoryImpl(dao, mapper);
   }
 
   @Bean

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/FileReportControllerImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/FileReportControllerImpl.java
@@ -8,7 +8,6 @@ import jakarta.validation.constraints.NotNull;
 import java.util.Collection;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.modelmapper.ModelMapper;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,13 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class FileReportControllerImpl implements FileReportController {
 
   private final FileReportService fileReportService;
-  private final ModelMapper modelMapper = FileReportDtoMapper.createDtoDomainMapper();
+  private final FileReportDtoMapper mapper;
 
   @Override
   public FileReportDto getFileReport(Collection<String> senderCodes) {
     log.info("GET file report for sender codes: {}", senderCodes.toString());
-    return modelMapper.map(fileReportService.getAggregateFileReport(senderCodes),
-        FileReportDto.class);
+    return mapper.fileReportToDto(fileReportService.getAggregateFileReport(senderCodes));
   }
 
   @Override

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/model/FileReportDtoMapper.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/model/FileReportDtoMapper.java
@@ -1,23 +1,15 @@
 package it.gov.pagopa.rtd.ms.rtdmsfilereporter.controller.model;
 
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
-import org.modelmapper.ModelMapper;
-import org.modelmapper.TypeMap;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
 
-public class FileReportDtoMapper {
+@Mapper(componentModel = "spring")
+public interface FileReportDtoMapper {
 
-  private FileReportDtoMapper() {
-  }
+  FileReportDtoMapper INSTANCE = Mappers.getMapper(FileReportDtoMapper.class);
 
-  public static ModelMapper createDtoDomainMapper() {
-    ModelMapper modelMapper = new ModelMapper();
-    // add custom conversion from filesUploaded to filesRecentlyUploaded
-    TypeMap<FileReport, FileReportDto> propertyMapper = modelMapper.createTypeMap(FileReport.class,
-        FileReportDto.class);
-    propertyMapper.addMapping(FileReport::getFilesUploaded,
-        FileReportDto::setFilesRecentlyUploaded);
-
-    return modelMapper;
-  }
-
+  @Mapping(source = "filesUploaded", target = "filesRecentlyUploaded")
+  FileReportDto fileReportToDto(FileReport fileReport);
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/model/FileReportDtoMapper.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/model/FileReportDtoMapper.java
@@ -3,12 +3,9 @@ package it.gov.pagopa.rtd.ms.rtdmsfilereporter.controller.model;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
 
 @Mapper(componentModel = "spring")
 public interface FileReportDtoMapper {
-
-  FileReportDtoMapper INSTANCE = Mappers.getMapper(FileReportDtoMapper.class);
 
   @Mapping(source = "filesUploaded", target = "filesRecentlyUploaded")
   FileReportDto fileReportToDto(FileReport fileReport);

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/FileReportCommandFactory.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/domain/FileReportCommandFactory.java
@@ -8,13 +8,12 @@ import java.util.function.BiConsumer;
 public class FileReportCommandFactory {
 
   public BiConsumer<FileReport, FileMetadata> getCommandByStatus(String status) {
-    switch (EventStatusEnum.valueOf(status)) {
-      case ACK_TO_DOWNLOAD:
-        return (fileReport, fileMetadata) -> fileReport.addAckToDownload(fileMetadata.getName());
-      case ACK_DOWNLOADED:
-        return (fileReport, fileMetadata) -> fileReport.removeAckToDownload(fileMetadata.getName());
-      default:
-        return FileReport::addFileOrUpdateStatusIfPresent;
-    }
+    return switch (EventStatusEnum.valueOf(status)) {
+      case ACK_TO_DOWNLOAD ->
+          (fileReport, fileMetadata) -> fileReport.addAckToDownload(fileMetadata.getName());
+      case ACK_DOWNLOADED ->
+          (fileReport, fileMetadata) -> fileReport.removeAckToDownload(fileMetadata.getName());
+      default -> FileReport::addFileOrUpdateStatusIfPresent;
+    };
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/FileReportEventAdapter.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/FileReportEventAdapter.java
@@ -1,7 +1,6 @@
 package it.gov.pagopa.rtd.ms.rtdmsfilereporter.event;
 
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.FileReportCommandFactory;
-import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileMetadata;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.service.FileReportService;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model.EventToDomainMapper;
@@ -26,7 +25,7 @@ public class FileReportEventAdapter {
 
   private final FileReportService service;
   private final Validator validator;
-  private final EventToDomainMapper modelMapper;
+  private final EventToDomainMapper mapper;
   private final FileReportCommandFactory fileReportCommandFactory;
 
   public void consumeEvent(@Valid ProjectorEventDto eventDto) {
@@ -43,7 +42,7 @@ public class FileReportEventAdapter {
 
     // execute command on report
     fileReportCommandFactory.getCommandByStatus(eventDto.getStatus().name())
-        .accept(report, modelMapper.eventToDomain(eventDto));
+        .accept(report, mapper.eventToDomain(eventDto));
 
     // remove from the report the old files
     report.removeFilesOlderThan(fileTimeToLiveInDays);

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/FileReportEventAdapter.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/FileReportEventAdapter.java
@@ -12,7 +12,6 @@ import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -27,7 +26,7 @@ public class FileReportEventAdapter {
 
   private final FileReportService service;
   private final Validator validator;
-  private final ModelMapper modelMapper = EventToDomainMapper.createEventDomainMapper();
+  private final EventToDomainMapper modelMapper;
   private final FileReportCommandFactory fileReportCommandFactory;
 
   public void consumeEvent(@Valid ProjectorEventDto eventDto) {
@@ -44,7 +43,7 @@ public class FileReportEventAdapter {
 
     // execute command on report
     fileReportCommandFactory.getCommandByStatus(eventDto.getStatus().name())
-        .accept(report, modelMapper.map(eventDto, FileMetadata.class));
+        .accept(report, modelMapper.eventToDomain(eventDto));
 
     // remove from the report the old files
     report.removeFilesOlderThan(fileTimeToLiveInDays);

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/EventToDomainMapper.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/EventToDomainMapper.java
@@ -4,12 +4,9 @@ import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileMetadata;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileStatusEnum;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
 
 @Mapper(componentModel = "spring")
 public interface EventToDomainMapper {
-
-  EventToDomainMapper INSTANCE = Mappers.getMapper(EventToDomainMapper.class);
 
   @Mapping(source = "fileName", target = "name")
   @Mapping(source = "receiveTimestamp", target = "transmissionDate")

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/EventToDomainMapper.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/EventToDomainMapper.java
@@ -2,47 +2,26 @@ package it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model;
 
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileMetadata;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileStatusEnum;
-import org.modelmapper.Converter;
-import org.modelmapper.ModelMapper;
-import org.modelmapper.TypeMap;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
 
-public class EventToDomainMapper {
+@Mapper(componentModel = "spring")
+public interface EventToDomainMapper {
 
-  private EventToDomainMapper() {
-  }
+  EventToDomainMapper INSTANCE = Mappers.getMapper(EventToDomainMapper.class);
 
-  public static ModelMapper createEventDomainMapper() {
-    ModelMapper modelMapper = new ModelMapper();
+  @Mapping(source = "fileName", target = "name")
+  @Mapping(source = "receiveTimestamp", target = "transmissionDate")
+  FileMetadata eventToDomain(ProjectorEventDto eventDto);
 
-    // mapping between fields
-    TypeMap<ProjectorEventDto, FileMetadata> propertyMapper = modelMapper.createTypeMap(
-        ProjectorEventDto.class, FileMetadata.class);
-    propertyMapper.addMapping(ProjectorEventDto::getFileName, FileMetadata::setName);
-    propertyMapper.addMapping(ProjectorEventDto::getReceiveTimestamp,
-        FileMetadata::setTransmissionDate);
-
-    // mapping from event status to domain status
-    Converter<EventStatusEnum, FileStatusEnum> mapStatus = context -> convertFromStringToStatusEnum(
-        context.getSource());
-    propertyMapper.addMappings(mapper -> mapper.using(mapStatus)
-        .map(ProjectorEventDto::getStatus, FileMetadata::setStatus));
-
-    return modelMapper;
-  }
-
-  private static FileStatusEnum convertFromStringToStatusEnum(EventStatusEnum status) {
-    switch (status) {
-      case RECEIVED:
-        return FileStatusEnum.RECEIVED_BY_PAGOPA;
-      case DECRYPTED:
-        return FileStatusEnum.VALIDATED_BY_PAGOPA;
-      case SENT_TO_ADE:
-        return FileStatusEnum.SENT_TO_AGENZIA_DELLE_ENTRATE;
-      case ACK_DOWNLOADED:
-        return FileStatusEnum.ACK_DOWNLOADED;
-      case ACK_TO_DOWNLOAD:
-        return FileStatusEnum.ACK_TO_DOWNLOAD;
-    }
-    return null;
+  default FileStatusEnum convertFromStringToStatusEnum(EventStatusEnum status) {
+    return switch (status) {
+      case RECEIVED -> FileStatusEnum.RECEIVED_BY_PAGOPA;
+      case DECRYPTED -> FileStatusEnum.VALIDATED_BY_PAGOPA;
+      case SENT_TO_ADE -> FileStatusEnum.SENT_TO_AGENZIA_DELLE_ENTRATE;
+      case ACK_DOWNLOADED -> FileStatusEnum.ACK_DOWNLOADED;
+      case ACK_TO_DOWNLOAD -> FileStatusEnum.ACK_TO_DOWNLOAD;
+    };
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImpl.java
@@ -2,19 +2,17 @@ package it.gov.pagopa.rtd.ms.rtdmsfilereporter.persistance;
 
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.repository.FileReportRepository;
-import it.gov.pagopa.rtd.ms.rtdmsfilereporter.persistance.model.FileReportEntity;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.persistance.model.FileReportEntityMapper;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.modelmapper.ModelMapper;
 
 @RequiredArgsConstructor
 public class FileReportRepositoryImpl implements FileReportRepository {
 
   private final FileReportDao fileReportDao;
-  private final ModelMapper modelMapper;
+  private final FileReportEntityMapper mapper;
 
   @Override
   public Collection<FileReport> getReportsBySenderCodes(Collection<String> senderCodes) {
@@ -23,19 +21,19 @@ public class FileReportRepositoryImpl implements FileReportRepository {
       return Collections.singletonList(FileReport.createFileReport());
     } else {
       return fileReportEntities.stream()
-          .map(entity -> modelMapper.map(entity, FileReport.class))
-          .collect(Collectors.toList());
+          .map(mapper::entityToDomain)
+          .toList();
     }
   }
 
   @Override
   public Optional<FileReport> getReportBySenderCode(String senderCode) {
     return fileReportDao.findBySenderCode(senderCode)
-        .map(entity -> modelMapper.map(entity, FileReport.class));
+        .map(mapper::entityToDomain);
   }
 
   @Override
   public void save(FileReport fileReport) {
-    fileReportDao.save(modelMapper.map(fileReport, FileReportEntity.class));
+    fileReportDao.save(mapper.domainToEntity(fileReport));
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/model/FileReportEntityMapper.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/model/FileReportEntityMapper.java
@@ -3,33 +3,27 @@ package it.gov.pagopa.rtd.ms.rtdmsfilereporter.persistance.model;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
 import java.util.Collection;
 import java.util.Collections;
-import org.modelmapper.Converter;
-import org.modelmapper.ModelMapper;
+import java.util.Set;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
 
-public class FileReportEntityMapper {
+@Mapper(componentModel = "spring")
+public interface FileReportEntityMapper {
 
-  private FileReportEntityMapper() {
+  FileReportEntityMapper INSTANCE = Mappers.getMapper(FileReportEntityMapper.class);
+
+  @Mapping(source = "senderCode", target = "senderCodes")
+  FileReport entityToDomain(FileReportEntity entity);
+
+  @Mapping(source = "senderCodes", target = "senderCode")
+  FileReportEntity domainToEntity(FileReport domain);
+
+  default String mapListToString(Collection<String> relation) {
+    return relation.stream().findAny().orElse(null);
   }
 
-  public static ModelMapper createEntityDomainMapper() {
-    ModelMapper modelMapper = new ModelMapper();
-    // add custom conversion from list of sender codes to String and viceversa
-    Converter<String, Collection<String>> stringToCollection = c -> Collections.singleton(
-        c.getSource());
-    Converter<Collection<String>, String> collectionToString = c -> c.getSource().stream()
-        .findAny().orElse(null);
-
-    var propertyMapperEntityToDomain = modelMapper.createTypeMap(
-        FileReportEntity.class, FileReport.class);
-    propertyMapperEntityToDomain.addMappings(mapper -> mapper.using(stringToCollection)
-        .map(FileReportEntity::getSenderCode, FileReport::setSenderCodes));
-
-    var propertyMapperDomainToEntity = modelMapper.createTypeMap(FileReport.class,
-        FileReportEntity.class);
-    propertyMapperDomainToEntity.addMappings(mapper -> mapper.using(collectionToString)
-        .map(FileReport::getSenderCodes, FileReportEntity::setSenderCode));
-
-    return modelMapper;
+  default Collection<String> mapStringToList(String value) {
+    return value == null ? Collections.emptySet() : Set.of(value);
   }
-
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/model/FileReportEntityMapper.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/model/FileReportEntityMapper.java
@@ -6,12 +6,9 @@ import java.util.Collections;
 import java.util.Set;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
 
 @Mapper(componentModel = "spring")
 public interface FileReportEntityMapper {
-
-  FileReportEntityMapper INSTANCE = Mappers.getMapper(FileReportEntityMapper.class);
 
   @Mapping(source = "senderCode", target = "senderCodes")
   FileReport entityToDomain(FileReportEntity entity);

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/DomainToDtoMapperTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/DomainToDtoMapperTest.java
@@ -1,0 +1,43 @@
+package it.gov.pagopa.rtd.ms.rtdmsfilereporter.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.controller.model.FileMetadataDto;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.controller.model.FileReportDtoMapper;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileMetadata;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileStatusEnum;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.Test;
+
+class DomainToDtoMapperTest {
+
+  private final FileReportDtoMapper mapper = FileReportDtoMapper.INSTANCE;
+
+  @Test
+  void mappingFromDomainToDtoWorksCorrectly() {
+    var currentDate = LocalDateTime.now();
+    FileReport fileReport = FileReport.createFileReport();
+    FileMetadata fileMetadata = new FileMetadata("file", 3000L, FileStatusEnum.RECEIVED_BY_PAGOPA,
+        currentDate);
+    fileReport.addFileUploaded(fileMetadata);
+    fileReport.addAckToDownload("ack1");
+    fileReport.setSenderCodes(List.of("senderCode"));
+
+    var fileReportDto = mapper.fileReportToDto(fileReport);
+
+    assertThat(fileReportDto).isNotNull();
+    assertThat(fileReportDto.getFilesRecentlyUploaded()).isNotNull().hasSize(1)
+        .extracting(FileMetadataDto::getName,
+            FileMetadataDto::getSize,
+            FileMetadataDto::getStatus,
+            FileMetadataDto::getTransmissionDate)
+        .doesNotContainNull()
+        .containsExactly(
+            Tuple.tuple("file", 3000L, FileStatusEnum.RECEIVED_BY_PAGOPA.name(), currentDate));
+  }
+
+
+}

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/DomainToDtoMapperTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/DomainToDtoMapperTest.java
@@ -11,10 +11,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
 
 class DomainToDtoMapperTest {
 
-  private final FileReportDtoMapper mapper = FileReportDtoMapper.INSTANCE;
+  private final FileReportDtoMapper mapper = Mappers.getMapper(FileReportDtoMapper.class);
 
   @Test
   void mappingFromDomainToDtoWorksCorrectly() {

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/FileReportControllerImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/controller/FileReportControllerImplTest.java
@@ -17,6 +17,7 @@ import java.util.HashSet;
 import lombok.SneakyThrows;
 import org.assertj.core.util.Sets;
 import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
 import org.mockito.ArgumentMatchers;
 import org.mockito.BDDMockito;
 import org.mockito.Mockito;
@@ -69,7 +70,7 @@ class FileReportControllerImplTest {
   @Test
   void givenReportWhenGetFileReportThenReturnCorrectJson() {
     var reportMock = TestUtils.createFileReport(2, 2);
-    var reportDto = FileReportDtoMapper.INSTANCE.fileReportToDto(reportMock);
+    var reportDto = Mappers.getMapper(FileReportDtoMapper.class).fileReportToDto(reportMock);
     Mockito.when(mapper.fileReportToDto(any())).thenReturn(reportDto);
 
     MvcResult result = mockMvc.perform(

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/FileReportEventAdapterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/FileReportEventAdapterTest.java
@@ -12,16 +12,17 @@ import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.service.FileReportService;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model.EventStatusEnum;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model.EventToDomainMapper;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model.ProjectorEventDto;
-import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.Optional;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Optional;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -33,7 +34,7 @@ class FileReportEventAdapterTest {
   private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
   private FileReportEventAdapter adapter;
   private AutoCloseable autoCloseable;
-  private final EventToDomainMapper mapper = EventToDomainMapper.INSTANCE;
+  private final EventToDomainMapper mapper = Mappers.getMapper(EventToDomainMapper.class);
   private final int fileTTL = 10;
 
   @BeforeEach

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/FileReportEventAdapterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/FileReportEventAdapterTest.java
@@ -10,6 +10,7 @@ import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileStatusEnum;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.service.FileReportService;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model.EventStatusEnum;
+import it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model.EventToDomainMapper;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model.ProjectorEventDto;
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -32,12 +33,13 @@ class FileReportEventAdapterTest {
   private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
   private FileReportEventAdapter adapter;
   private AutoCloseable autoCloseable;
+  private final EventToDomainMapper mapper = EventToDomainMapper.INSTANCE;
   private final int fileTTL = 10;
 
   @BeforeEach
   void setUp() {
     autoCloseable = MockitoAnnotations.openMocks(this);
-    adapter = new FileReportEventAdapter(service, validator, new FileReportCommandFactory());
+    adapter = new FileReportEventAdapter(service, validator, mapper, new FileReportCommandFactory());
     adapter.setFileTimeToLiveInDays(fileTTL);
   }
 

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/EventToDomainMapperTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/EventToDomainMapperTest.java
@@ -2,18 +2,16 @@ package it.gov.pagopa.rtd.ms.rtdmsfilereporter.event.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileMetadata;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileStatusEnum;
 import java.time.LocalDateTime;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.modelmapper.ModelMapper;
 
 class EventToDomainMapperTest {
 
-  private final ModelMapper modelMapper = EventToDomainMapper.createEventDomainMapper();
+  private final EventToDomainMapper mapper = EventToDomainMapper.INSTANCE;
 
   private static Stream<Arguments> provideStatus() {
     return Stream.of(
@@ -33,7 +31,7 @@ class EventToDomainMapperTest {
     var eventDto = new ProjectorEventDto("filename", "12345", 100L, currentDate,
         eventStatus);
 
-    var domainFile = modelMapper.map(eventDto, FileMetadata.class);
+    var domainFile = mapper.eventToDomain(eventDto);
 
     assertThat(domainFile).isNotNull();
     assertThat(domainFile.getName()).isEqualTo("filename");

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/EventToDomainMapperTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/event/model/EventToDomainMapperTest.java
@@ -8,10 +8,11 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mapstruct.factory.Mappers;
 
 class EventToDomainMapperTest {
 
-  private final EventToDomainMapper mapper = EventToDomainMapper.INSTANCE;
+  private final EventToDomainMapper mapper = Mappers.getMapper(EventToDomainMapper.class);
 
   private static Stream<Arguments> provideStatus() {
     return Stream.of(

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportDaoTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportDaoTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -37,7 +38,7 @@ class FileReportDaoTest {
   @Autowired
   MongoTemplate mongoTemplate;
 
-  FileReportEntityMapper mapper = FileReportEntityMapper.INSTANCE;
+  FileReportEntityMapper mapper = Mappers.getMapper(FileReportEntityMapper.class);
 
   @BeforeEach
   void setUp() {

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportDaoTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportDaoTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -38,7 +37,7 @@ class FileReportDaoTest {
   @Autowired
   MongoTemplate mongoTemplate;
 
-  ModelMapper modelMapper = FileReportEntityMapper.createEntityDomainMapper();
+  FileReportEntityMapper mapper = FileReportEntityMapper.INSTANCE;
 
   @BeforeEach
   void setUp() {
@@ -61,7 +60,7 @@ class FileReportDaoTest {
   void givenOneReportWhenFindBySenderCodeThenReturnsOneReport() {
     var fileReport = TestUtils.createFileReport(2, 3);
     fileReport.setSenderCodes(List.of("12345"));
-    dao.save(modelMapper.map(fileReport, FileReportEntity.class));
+    dao.save(mapper.domainToEntity(fileReport));
 
     var entities = dao.findBySenderCodeIn(List.of("12345"));
 
@@ -77,9 +76,9 @@ class FileReportDaoTest {
     fileReport2.setSenderCodes(List.of("67890"));
     var fileReport3 = TestUtils.createFileReport(1, 2);
     fileReport3.setSenderCodes(List.of("46801"));
-    dao.save(modelMapper.map(fileReport, FileReportEntity.class));
-    dao.save(modelMapper.map(fileReport2, FileReportEntity.class));
-    dao.save(modelMapper.map(fileReport3, FileReportEntity.class));
+    dao.save(mapper.domainToEntity(fileReport));
+    dao.save(mapper.domainToEntity(fileReport2));
+    dao.save(mapper.domainToEntity(fileReport3));
 
     var entities = dao.findBySenderCodeIn(List.of("12345", "67890"));
 

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImplTest.java
@@ -20,6 +20,7 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -31,7 +32,7 @@ class FileReportRepositoryImplTest {
 
   FileReportRepository repository;
 
-  FileReportEntityMapper mapper = FileReportEntityMapper.INSTANCE;
+  FileReportEntityMapper mapper = Mappers.getMapper(FileReportEntityMapper.class);
   AutoCloseable autoCloseable;
 
   @BeforeEach

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfilereporter/persistance/FileReportRepositoryImplTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.verify;
 
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.TestUtils;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileMetadata;
-import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileReport;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.model.FileStatusEnum;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.domain.repository.FileReportRepository;
 import it.gov.pagopa.rtd.ms.rtdmsfilereporter.persistance.model.FileReportEntity;
@@ -24,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.modelmapper.ModelMapper;
 
 class FileReportRepositoryImplTest {
 
@@ -33,13 +31,13 @@ class FileReportRepositoryImplTest {
 
   FileReportRepository repository;
 
-  ModelMapper modelMapper = FileReportEntityMapper.createEntityDomainMapper();
+  FileReportEntityMapper mapper = FileReportEntityMapper.INSTANCE;
   AutoCloseable autoCloseable;
 
   @BeforeEach
   void setUp() {
     autoCloseable = MockitoAnnotations.openMocks(this);
-    repository = new FileReportRepositoryImpl(dao, modelMapper);
+    repository = new FileReportRepositoryImpl(dao, mapper);
   }
 
   @SneakyThrows
@@ -84,7 +82,7 @@ class FileReportRepositoryImplTest {
     var reportStub = TestUtils.createFileReport(1, 1);
     reportStub.setSenderCodes(Collections.singleton("12345"));
     Mockito.when(dao.findBySenderCode("12345")).thenReturn(
-        Optional.of(modelMapper.map(reportStub, FileReportEntity.class)));
+        Optional.of(mapper.domainToEntity(reportStub)));
 
     var fileReport = repository.getReportBySenderCode("12345");
 
@@ -104,7 +102,7 @@ class FileReportRepositoryImplTest {
     fileReportEntity.setAckToDownload(List.of("ack1", "ack2"));
     fileReportEntity.setId("testID");
 
-    var fileReport = modelMapper.map(fileReportEntity, FileReport.class);
+    var fileReport = mapper.entityToDomain(fileReportEntity);
 
     assertThat(fileReport).isNotNull();
     assertThat(fileReport.getFilesUploaded()).isNotNull().hasSize(1)
@@ -122,13 +120,13 @@ class FileReportRepositoryImplTest {
 
     repository.save(reportStub);
 
-    verify(dao).save(modelMapper.map(reportStub, FileReportEntity.class));
+    verify(dao).save(mapper.domainToEntity(reportStub));
   }
 
   Collection<FileReportEntity> getMockedReports() {
     var reports = new ArrayList<FileReportEntity>();
-    reports.add(modelMapper.map(TestUtils.createFileReport(1, 1), FileReportEntity.class));
-    reports.add(modelMapper.map(TestUtils.createFileReport(2, 1), FileReportEntity.class));
+    reports.add(mapper.domainToEntity(TestUtils.createFileReport(1, 1)));
+    reports.add(mapper.domainToEntity(TestUtils.createFileReport(2, 1)));
     return reports;
   }
 


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to replace the modelMapper library with mapStruct.
The change is motivated by several reasons:
- modelMapper do not support native compilation
- mapStruct is better maintained, most adopted
- mapStruct works entirely at compile time ensuring compatibility with native compilation and better performance
#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore change (non-breaking change which doesn't provide a direct value to users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
